### PR TITLE
base.html template

### DIFF
--- a/readthedocs-theme/templates/base.html
+++ b/readthedocs-theme/templates/base.html
@@ -1,10 +1,51 @@
-{% extends "!simple/base.html" %}
+<!DOCTYPE html>
+<html lang="{% block html_lang %}{{ DEFAULT_LANG }}{% endblock html_lang %}">
 
-{%- block head %}
-  {{ super() }}
-  <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/site.css" />
-  <link href="{{ SITEURL }}/{{ FEED }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} ATOM Feed" />
-  <link href="{{ SITEURL }}/{{ FEED_RSS }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
-  <script src="{{ SITEURL }}/theme/js/vendor.js"></script>
-  <script src="{{ SITEURL }}/theme/js/site.js"></script>
-{% endblock head -%}
+<head>
+  {% block head %}
+    <title>{% block title %}{{ SITENAME }}{% endblock title %}</title>
+    <meta charset="utf-8" />
+    <meta name="generator" content="Pelican" />
+    {% if FEED_ALL_ATOM %}
+    <link href="{{ FEED_DOMAIN }}/{% if FEED_ALL_ATOM_URL %}{{ FEED_ALL_ATOM_URL }}{% else %}{{ FEED_ALL_ATOM }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Full Atom Feed" />
+    {% endif %}
+    {% if FEED_ALL_RSS %}
+    <link href="{{ FEED_DOMAIN }}/{% if FEED_ALL_RSS_URL %}{{ FEED_ALL_RSS_URL }}{% else %}{{ FEED_ALL_RSS }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Full RSS Feed" />
+    {% endif %}
+    {% if FEED_ATOM %}
+    <link href="{{ FEED_DOMAIN }}/{%if FEED_ATOM_URL %}{{ FEED_ATOM_URL }}{% else %}{{ FEED_ATOM }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Atom Feed" />
+    {% endif %}
+    {% if FEED_RSS %}
+      <link href="{{ FEED_DOMAIN }}/{% if FEED_RSS_URL %}{{ FEED_RSS_URL }}{% else %}{{ FEED_RSS }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
+    {% endif %}
+    {% if CATEGORY_FEED_ATOM and category %}
+      <link href="{{ FEED_DOMAIN }}/{% if CATEGORY_FEED_ATOM_URL %}{{ CATEGORY_FEED_ATOM_URL.format(slug=category.slug) }}{% else %}{{ CATEGORY_FEED_ATOM.format(slug=category.slug) }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Categories Atom Feed" />
+    {% endif %}
+    {% if CATEGORY_FEED_RSS and category %}
+      <link href="{{ FEED_DOMAIN }}/{% if CATEGORY_FEED_RSS_URL %}{{ CATEGORY_FEED_RSS_URL.format(slug=category.slug) }}{% else %}{{ CATEGORY_FEED_RSS.format(slug=category.slug) }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Categories RSS Feed" />
+    {% endif %}
+    {% if TAG_FEED_ATOM and tag %}
+      <link href="{{ FEED_DOMAIN }}/{% if TAG_FEED_ATOM_URL %}{{ TAG_FEED_ATOM_URL.format(slug=tag.slug) }}{% else %}{{ TAG_FEED_ATOM.format(slug=tag.slug) }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tags Atom Feed" />
+    {% endif %}
+    {% if TAG_FEED_RSS and tag %}
+      <link href="{{ FEED_DOMAIN }}/{% if TAG_FEED_RSS_URL %}{{ TAG_FEED_RSS_URL.format(slug=tag.slug) }}{% else %}{{ TAG_FEED_RSS.format(slug=tag.slug) }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tags RSS Feed" />
+    {% endif %}
+
+          
+    <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/site.css" />
+    <link href="{{ SITEURL }}/{{ FEED }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} ATOM Feed" />
+    <link href="{{ SITEURL }}/{{ FEED_RSS }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
+    <script src="{{ SITEURL }}/theme/js/vendor.js"></script>
+    <script src="{{ SITEURL }}/theme/js/site.js"></script>
+  {% endblock head %}
+</head>
+
+<body {% block body_attributes %}{% endblock %}>
+  {% block topnav %}
+  {% endblock %}
+  {% block content %}
+  {% endblock %}
+  {% block footer %}
+  {% endblock %}
+</body>
+</html>

--- a/readthedocs-theme/templates/readthedocs/homepage.html
+++ b/readthedocs-theme/templates/readthedocs/homepage.html
@@ -1,5 +1,9 @@
 {% extends "page.html" %}
 
+{% block body_attributes %}
+  id="home" 
+{% endblock %}
+
 {% block content %}
   <div class="ui container">
     <div class="ui segment">


### PR DESCRIPTION
The basic structure for our base template with the `topnav`, `content` and `footer` `{% blocks %}`.

I also added the option for custom `<body>` attributes and removed the inheritance from the Pelican's `!simple/base.html` and copied the file's `links` and `metadata` here for now. Later we'll probably want to add more configuration there and move the common data to an `include/`, like on [ethicalads.io](https://github.com/readthedocs/ethicalads.io/blob/main/ethicalads-theme/templates/base.html).