### PR TITLE
Add page title logic

### DIFF
--- a/readthedocs-theme/templates/page.html
+++ b/readthedocs-theme/templates/page.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block html_lang %}{{ page.lang }}{% endblock %}
+
+
+{% block title %}{% if page.title %}{{ page.title|striptags }} - {% endif %}{{ SITENAME }}{%endblock%}


### PR DESCRIPTION
Add page "Subtitle -Title" logic to the base `page.html` template and allows inheritance for the page subtitle.

* Change prompted by comment: https://github.com/readthedocs/site-community/pull/34/files#r789104336