### PR TITLE
Add href and class .active to topnav links

### DIFF
--- a/readthedocs-theme/templates/includes/topnav.html
+++ b/readthedocs-theme/templates/includes/topnav.html
@@ -5,10 +5,10 @@
       <div class="ui image readthedocs-logo"><img src="{{ SITEURL }}/theme/img/logo-wordmark-dark.svg"/></div>
     </a>
 
-    <a class="item{% if page and page.slug == "product" %} active{% endif %}" href="{{ SITEURL }}/product.html">Product{% if page and page.slug == "product" %} <span class="sr-only">(current)</span>{% endif %}</a>
-    <a class="item{% if page and page.slug == "pricing" %} active{% endif %}" href="{{ SITEURL }}/pricing.html">Pricing{% if page and page.slug == "pricing" %} <span class="sr-only">(current)</span>{% endif %}</a>
-    <a class="item{% if page and page.slug == "company" %} active{% endif %}" href="{{ SITEURL }}/company.html">Company{% if page and page.slug == "company" %} <span class="sr-only">(current)</span>{% endif %}</a>
-    <a class="item{% if page and page.slug == "resources" %} active{% endif %}" href="">Resources{% if page and page.slug == "resources" %} <span class="sr-only">(current)</span>{% endif %}</a>
+    <a class="item{% if page and page.slug == 'product' %} active" aria-current="page{% endif %}" href="{{ SITEURL }}/product.html">Product</a>
+    <a class="item{% if page and page.slug == 'pricing' %} active" aria-current="page{% endif %}" href="{{ SITEURL }}/pricing.html">Pricing</a>
+    <a class="item{% if page and page.slug == 'company' %} active" aria-current="page{% endif %}" href="{{ SITEURL }}/company.html">Company</a>
+    <a class="item{% if page and page.slug == 'resources' %} active" aria-current="page{% endif %}" href="">Resources</a>
 
     <div class="right menu">
       <a class="item" href="">Support</a>

--- a/readthedocs-theme/templates/includes/topnav.html
+++ b/readthedocs-theme/templates/includes/topnav.html
@@ -1,14 +1,14 @@
 <div class="ui menu fixed borderless" id="topnav">
   <div class="ui container">
 
-    <a class="header item" href="">
-      <div class="ui image readthedocs-logo"><img src="/theme/img/logo-wordmark-dark.svg"/></div>
+    <a class="header item" href="{{ SITEURL }}/">
+      <div class="ui image readthedocs-logo"><img src="{{ SITEURL }}/theme/img/logo-wordmark-dark.svg"/></div>
     </a>
 
-    <a class="item active" href="">Product</a>
-    <a class="item" href="">Pricing</a>
-    <a class="item" href="">Company</a>
-    <a class="item" href="">Resources</a>
+    <a class="item{% if output_file == page.save_as %} active{% endif %}" href="{{ SITEURL }}/product.html">Product{% if output_file == page.save_as %} <span class="sr-only">(current)</span>{% endif %}</a>
+    <a class="item{% if output_file == page.save_as %} active{% endif %}" href="{{ SITEURL }}/pricing.html">Pricing{% if output_file == page.save_as %} <span class="sr-only">(current)</span>{% endif %}</a>
+    <a class="item{% if output_file == page.save_as %} active{% endif %}" href="{{ SITEURL }}/company.html">Company{% if output_file == page.save_as %} <span class="sr-only">(current)</span>{% endif %}</a>
+    <a class="item{% if output_file == page.save_as %} active{% endif %}" href="">Resources{% if output_file == page.save_as %} <span class="sr-only">(current)</span>{% endif %}</a>
 
     <div class="right menu">
       <a class="item" href="">Support</a>

--- a/readthedocs-theme/templates/includes/topnav.html
+++ b/readthedocs-theme/templates/includes/topnav.html
@@ -5,10 +5,10 @@
       <div class="ui image readthedocs-logo"><img src="{{ SITEURL }}/theme/img/logo-wordmark-dark.svg"/></div>
     </a>
 
-    <a class="item{% if output_file == page.save_as %} active{% endif %}" href="{{ SITEURL }}/product.html">Product{% if output_file == page.save_as %} <span class="sr-only">(current)</span>{% endif %}</a>
-    <a class="item{% if output_file == page.save_as %} active{% endif %}" href="{{ SITEURL }}/pricing.html">Pricing{% if output_file == page.save_as %} <span class="sr-only">(current)</span>{% endif %}</a>
-    <a class="item{% if output_file == page.save_as %} active{% endif %}" href="{{ SITEURL }}/company.html">Company{% if output_file == page.save_as %} <span class="sr-only">(current)</span>{% endif %}</a>
-    <a class="item{% if output_file == page.save_as %} active{% endif %}" href="">Resources{% if output_file == page.save_as %} <span class="sr-only">(current)</span>{% endif %}</a>
+    <a class="item{% if page and page.slug == "product" %} active{% endif %}" href="{{ SITEURL }}/product.html">Product{% if page and page.slug == "product" %} <span class="sr-only">(current)</span>{% endif %}</a>
+    <a class="item{% if page and page.slug == "pricing" %} active{% endif %}" href="{{ SITEURL }}/pricing.html">Pricing{% if page and page.slug == "pricing" %} <span class="sr-only">(current)</span>{% endif %}</a>
+    <a class="item{% if page and page.slug == "company" %} active{% endif %}" href="{{ SITEURL }}/company.html">Company{% if page and page.slug == "company" %} <span class="sr-only">(current)</span>{% endif %}</a>
+    <a class="item{% if page and page.slug == "resources" %} active{% endif %}" href="">Resources{% if page and page.slug == "resources" %} <span class="sr-only">(current)</span>{% endif %}</a>
 
     <div class="right menu">
       <a class="item" href="">Support</a>


### PR DESCRIPTION
Add `href` to pages that are already being developed and make the class `.active` dynamic, as expected.

_Note 1: This PR won't display anything new before the pages PRs are merged but can be merged before._
_Note 2: I also started adding the `{{ SITEURL }}` variable to internal links._


Fixes: #37 