### PR TITLE
Example of automatic page id without a special template

### DIFF
--- a/content/pages/homepage.md
+++ b/content/pages/homepage.md
@@ -1,5 +1,4 @@
-title: Read the Docs
-subtitle: Example subtitle
+title: Home
 template: readthedocs/homepage
 save_as: index.html
 status: hidden

--- a/readthedocs-theme/templates/base.html
+++ b/readthedocs-theme/templates/base.html
@@ -40,7 +40,7 @@
   {% endblock head %}
 </head>
 
-<body id="{% block body_id %}home{% endblock body_id %}">
+<body id="{% block body_id %}{% endblock body_id %}">
   {% include 'includes/topnav.html' %}
   
   <main>{% block content %}{% endblock %}</main>

--- a/readthedocs-theme/templates/page.html
+++ b/readthedocs-theme/templates/page.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block html_lang %}{{ page.lang }}{% endblock %}
 
+{% block body_id %}page-{{ page.slug }}{% endblock body_id %}
 
 {% block title %}{% if page.title %}{{ page.title|striptags }} - {% endif %}{{ SITENAME }}{%endblock%}

--- a/readthedocs-theme/templates/readthedocs/homepage.html
+++ b/readthedocs-theme/templates/readthedocs/homepage.html
@@ -1,7 +1,5 @@
 {% extends "page.html" %}
 
-{% block body_id %}home{% endblock %}
-
 {% block content %}
   <div class="ui container">
     <div class="ui segment">


### PR DESCRIPTION
So far, each page we've made has a special template. Eventually, pages
will share templates though, so hardcoding this won't be as useful. This
automates `<body id="page-home">` using `page.slug` for now.