### PR TITLE
Update .topnav links

### DIFF
--- a/readthedocs-theme/templates/includes/topnav.html
+++ b/readthedocs-theme/templates/includes/topnav.html
@@ -8,12 +8,12 @@
     <a class="item{% if page and page.slug == 'product' %} active" aria-current="page{% endif %}" href="{{ SITEURL }}/product.html">Product</a>
     <a class="item{% if page and page.slug == 'pricing' %} active" aria-current="page{% endif %}" href="{{ SITEURL }}/pricing.html">Pricing</a>
     <a class="item{% if page and page.slug == 'company' %} active" aria-current="page{% endif %}" href="{{ SITEURL }}/company.html">Company</a>
-    <a class="item{% if page and page.slug == 'resources' %} active" aria-current="page{% endif %}" href="">Resources</a>
+    <a class="item" target="_blank" href="https://docs.readthedocs.io/en/stable/guides/">Resources</a>
 
     <div class="right menu">
-      <a class="item" href="">Support</a>
+      <a class="item" target="_blank" href="https://docs.readthedocs.io/en/stable/support.html">Support</a>
       <div class="item">
-        <a class="ui button primary">
+        <a class="ui button primary" href="https://readthedocs.org/dashboard/">
           Open Application
         </a>
       </div>


### PR DESCRIPTION
Adds the missing links: **resources**, **support** and **application**.

The first two point outside the site, to the blog.
I used `target="_blank"` on these two so the user wouldn't loose the `.topnav` to navigate within the site.

Closes #47 