### PR TITLE
CSS: remove SUI link card underline

### DIFF
--- a/src/sui/themes/rtd-site/views/card.overrides
+++ b/src/sui/themes/rtd-site/views/card.overrides
@@ -27,3 +27,8 @@
 .ui.card .meta {
   line-height: @headerLineHeight;
 }
+
+a.card,
+a.card:hover {
+  text-decoration: none;
+}


### PR DESCRIPTION
Semantic UI `a.card` had no explicit `text-decoration` property applied, so was inheriting directly from the `a` styling, which is set to `{text-decoration:underline}`. This PR applies `{text-decoration:none}` to the `a.card`, removing the underline on the cards and allowing, in future, for the `a` text decoration to be changed without affecting the cards.

* Partially solves #61 
* Relates to https://github.com/readthedocs/site-community/pull/58#discussion_r801335542