### PR TITLE
Add images path to pelicanconf.py

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -44,7 +44,7 @@ MENUITEMS_CTA = []
 PATH = 'content'
 PAGE_PATHS = ['pages']
 ARTICLE_PATHS = ['posts']
-STATIC_PATHS = []
+STATIC_PATHS = ['images']
 
 # URL settings
 PAGE_URL = '{slug}/'


### PR DESCRIPTION
Images were not being built into `/output/images/` as expected.
This adds the images path to pelicanconf.py `STATIC_PATHS`