### PR TITLE
Open source is not a proper noun, it can be lower case

### DIFF
--- a/readthedocs-theme/templates/readthedocs/company.html
+++ b/readthedocs-theme/templates/readthedocs/company.html
@@ -16,7 +16,7 @@
           </h1>
           <div class="ui basic vertical huge segment center aligned">
             <p>
-              We are an Open Source project providing the tools, knowledge and hosting for some of the world's top teams' documentation.
+              We are an open source project providing the tools, knowledge and hosting for some of the world's top teams' documentation.
             </p>
           </div>
         </div>

--- a/readthedocs-theme/templates/readthedocs/company.html
+++ b/readthedocs-theme/templates/readthedocs/company.html
@@ -172,7 +172,7 @@
               </div>
               <div class="eleven wide column">
                 <p>
-                  We are honored to have several external contributors that have kept with us for a long time and helped us a lot along the way. Here we list just a few but the full list can be found at <a href="https://github.com/readthedocs/readthedocs.org/graphs/contributors">Github</a>.
+                  We are honored to have several external contributors that have kept with us for a long time and helped us a lot along the way. Here we list just a few but the full list can be found at <a href="https://github.com/readthedocs/readthedocs.org/graphs/contributors">GitHub</a>.
                 </p>
                 <p>
                   A heart felt thanks to all of you!


### PR DESCRIPTION
I'm not convinced that should be there either way though, RTD is a
company, not just an open source project.