### PR TITLE
Add card label icons in the product page

### DIFF
--- a/readthedocs-theme/templates/readthedocs/product.html
+++ b/readthedocs-theme/templates/readthedocs/product.html
@@ -173,7 +173,7 @@
           </div>
           <div class="extra content">
             <div class="ui labels">
-              <span class="ui label basic large"><i class="icon primary hourglass outline"></i> Version control</span>
+              <span class="ui label basic large"><i class="icon primary copy outline"></i> Version control</span>
             </div>
           </div>
         </div>
@@ -187,8 +187,8 @@
           </div>
           <div class="extra content">
             <div class="ui labels">
-              <span class="ui label basic large"><i class="icon primary hourglass outline"></i> reStructuredText</span>
-              <span class="ui label basic large"><i class="icon primary hourglass outline"></i> Markdown</span>
+              <span class="ui label basic large"><i class="icon primary file alternate outline"></i> reStructuredText</span>
+              <span class="ui label basic large"><i class="icon primary file alternate"></i> Markdown</span>
             </div>
           </div>
         </div>
@@ -202,7 +202,7 @@
           </div>
           <div class="extra content">
             <div class="ui labels">
-              <span class="ui label basic large"><i class="icon primary hourglass outline"></i> Always up to date</span>
+              <span class="ui label basic large"><i class="icon primary sync"></i> Always up to date</span>
             </div>
           </div>
         </div>
@@ -216,8 +216,8 @@
           </div>
           <div class="extra content">
             <div class="ui labels">
-              <span class="ui label basic large"><i class="icon primary hourglass outline"></i> Use familiar tools</span>
-              <span class="ui label basic large"><i class="icon primary hourglass outline"></i> Write docs like you code</span>
+              <span class="ui label basic large"><i class="icon primary laptop"></i> Use familiar tools</span>
+              <span class="ui label basic large"><i class="icon primary terminal"></i> Write docs like you code</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Adds the missing icons (previously placeholders) to the labels on the product page cards.

![screencapture-localhost-8080-product-html-2022-02-16-18_43_10](https://user-images.githubusercontent.com/4049894/154335542-e2b52e0d-e6d9-428f-ba9b-53a908189ba7.png)

_Note: sadly, sui has no icon remotely similar to a branch/git/version-control. I don't love the current option but I think it's the most closely related_

Closes: #76