### PR TITLE
Pricing page: Remove individual plans buttons

### DIFF
--- a/readthedocs-theme/templates/readthedocs/pricing.html
+++ b/readthedocs-theme/templates/readthedocs/pricing.html
@@ -31,8 +31,6 @@
               <span class="category">per month</span>
             </div>
 
-            <button class="ui button fluid large blue">Sign up</button>
-
             <div class="description">
               
               <div class="ui list inverted relaxed divided">
@@ -114,8 +112,6 @@
               <span class="category">per month</span>
             </div>
 
-            <button class="ui button fluid large orange">Sign up</button>
-
             <div class="description">
               
               <div class="ui list inverted relaxed divided">
@@ -169,8 +165,6 @@
             <div class="meta">
               <span class="category">per month</span>
             </div>
-
-            <button class="ui button fluid large yellow">Sign up</button>
 
             <div class="description">
               
@@ -251,8 +245,6 @@
               <span class="category">forever free</span>
             </div>
 
-            <button class="ui button fluid large blue">Sign up</button>
-
             <div class="description">
               
               <div class="ui list relaxed divided">
@@ -299,8 +291,6 @@
               <span class="right floated"><i>limited time</i></span>
             </div>
 
-            <button class="ui button fluid large orange">Donate</button>
-
             <div class="description">
               
               <div class="ui list relaxed divided">
@@ -327,8 +317,6 @@
             <div class="meta">
               <span class="category">per month</span>
             </div>
-
-            <button class="ui button fluid large yellow">Sign up</button>
 
             <div class="description">
               

--- a/readthedocs-theme/templates/readthedocs/pricing.html
+++ b/readthedocs-theme/templates/readthedocs/pricing.html
@@ -223,6 +223,14 @@
 
       </div>
 
+      
+      <div class="ui segment basic vertical padded center aligned">
+        <p>
+          <a class="ui button orange tiny" href="https://readthedocs.com/accounts/signup">Sign up</a>
+          for a business account.
+        </p>
+      </div>
+
       <div class="ui segment basic vertical padded">
         <div class="ui horizontal divider header massive">
           Base Plans
@@ -349,6 +357,13 @@
         </div>
         <!-- end card -->
         
+      </div>
+
+      
+      <div class="ui segment basic vertical padded center aligned">
+        <p>
+          <a class="ui button blue tiny" href="https://readthedocs.org/accounts/signup">Get started for free</a>
+        </p>
       </div>
 
     </div>


### PR DESCRIPTION
Removes the buttons on each plan card and adds 2 new buttons with links for signing up on  [**readthedocs.org/accounts/signup**](https://readthedocs.org/accounts/signup) and [**readthedocs.com/accounts/signup**](https://readthedocs.com/accounts/signup).

<br>

Preview:

![screencapture-localhost-8080-pricing-html-2022-02-22-10_33_32](https://user-images.githubusercontent.com/4049894/155114968-e50e871d-8c39-4c03-848e-1c9ae1a0620b.png)

* Closes: #80