### PR TITLE
Add announcements automation from blog posts

### DIFF
--- a/content/posts/test.md
+++ b/content/posts/test.md
@@ -1,6 +1,7 @@
 Title: Testing the new blog article template
 Date: Feb 1, 2022
-Tags: readthedocs, blog, article
+category: Announcement
+Tags: readthedocs, blog, article, homepage
 Authors: Anthony Johnson, Ana Costa
 Summary: Some mock content to test the new blog article template
 description: Some mock content to test the new blog article template

--- a/content/posts/test.rst
+++ b/content/posts/test.rst
@@ -2,7 +2,8 @@ Sphinx 4.4 release and other ecosystem news
 ###########################################
 
 :date: January 26, 2022
-:tags: sphinx, release
+:category: News
+:tags: sphinx, release, homepage
 :authors: Juan Luis
 :description: In this post we talk about the latest release of Sphinx 4.4 and include other relevant news from the Sphinx ecosystem of extensions and themes.
 :image: 

--- a/readthedocs-theme/templates/readthedocs/includes/announcements.html
+++ b/readthedocs-theme/templates/readthedocs/includes/announcements.html
@@ -40,7 +40,7 @@
                   We post important announcements, news and updates in this area. You can also check out our <a href="https://blog.readthedocs.com/">blog</a> or subscribe the newsletter to receive future updates first hand, plus receive our monthly report.
                 </p>
                 <p>
-                  <a href="#">Subscribe our newsletter</a>
+                  <a href="#">Subscribe to our newsletter</a>
                 </p>
               </div>
             </div>

--- a/readthedocs-theme/templates/readthedocs/includes/announcements.html
+++ b/readthedocs-theme/templates/readthedocs/includes/announcements.html
@@ -37,7 +37,7 @@
                 <div><span class="ui label">Update</span></div>
                 <h4>You are all up to date</h4>
                 <p>
-                  We post important announcements, news and updates in this area. You can also check out our <a href="https://blog.readthedocs.com/">blog</a> or subscribe the newsletter to receive future updates first hand, plus receive our monthly report.
+                  We post important announcements, news and updates in this area. You can also check out our <a href="/blog/">blog</a> or subscribe to our newsletter to receive future updates.
                 </p>
                 <p>
                   <a href="#">Subscribe to our newsletter</a>

--- a/readthedocs-theme/templates/readthedocs/includes/announcements.html
+++ b/readthedocs-theme/templates/readthedocs/includes/announcements.html
@@ -40,7 +40,7 @@
                   We post important announcements, news and updates in this area. You can also check out our <a href="/blog/">blog</a> or subscribe to our newsletter to receive future updates.
                 </p>
                 <p>
-                  <a href="#">Subscribe to our newsletter</a>
+                  <a target="_blank" href="https://landing.mailerlite.com/webforms/landing/p8b7z2">Subscribe to our newsletter</a>
                 </p>
               </div>
             </div>

--- a/readthedocs-theme/templates/readthedocs/includes/announcements.html
+++ b/readthedocs-theme/templates/readthedocs/includes/announcements.html
@@ -1,51 +1,53 @@
-
-  <section class="ui vertical segment" id="announcements">
-
-    <div class="ui container">
-
-      <div class="ui raised segment">
-        <div class="ui grid stackable three column">
-
-          <div class="column">
-            <div class="ui basic segment">
-              <div><span class="ui label red">Announcement</span></div>
-              <h4>Build errors with docutils 0.18</h4>
-              <p>
-                The latest Docutils and Sphinx updates have been the source of several problems on our builds. If you are experiencing problems related with this read the blog post. Well point you to several solutions.
-              </p>
-              <p>
-                <a href="https://blog.readthedocs.com/build-errors-docutils-0-18/">Learn how to solve it</a>
-              </p>
+<section class="ui vertical segment" id="announcements">
+  <div class="ui container">
+    <div class="ui raised segment">
+      <div class="ui grid stackable three column">
+        
+        {% for article in articles if 'homepage' in article.tags %}
+          {% if loop.index <= 3 %}
+            <div class="column">
+              <div class="ui basic segment">
+                <div>
+                  <span class="ui label {% if article.category == 'Announcement' %}red{% else %}primary{% endif %}">
+                    {# article.category defaults to 'posts' when no category is provided #}
+                    {% if article.category == 'posts' %}
+                      Article
+                    {% else %}
+                      {{ article.category }}
+                    {% endif %}
+                  </span>
+                </div>
+                <h4>{{ article.title }}</h4>
+                <p>
+                  {% if article.description %}
+                    {{ article.description|striptags|escape }}
+                  {% else %}
+                    {{ article.summary|striptags|escape }}
+                  {% endif %}
+                </p>
+                <p>
+                  <a href="/{{ article.url }}">Read more</a>
+                </p>
+              </div>
             </div>
-          </div>
-          <div class="column">
-            <div class="ui basic segment">
-              <div><span class="ui label primary">News</span></div>
-              <h4>Our Sphinx theme version 1.0.0 is out</h4>
-              <p>
-                We have released a major version 1.0.0 of our Sphinx theme. This adds support for recent versions of Sphinx and docutils among other very cool things. Check out the blog post.
-              </p>
-              <p>
-                <a href="https://blog.readthedocs.com/newsletter-september-2021/">Read more</a>
-              </p>
+          {% endif %}
+          {% if loop.last and loop.length < 3 %}
+            <div class="column">
+              <div class="ui basic segment">
+                <div><span class="ui label">Update</span></div>
+                <h4>You are all up to date</h4>
+                <p>
+                  We post important announcements, news and updates in this area. You can also check out our <a href="https://blog.readthedocs.com/">blog</a> or subscribe the newsletter to receive future updates first hand, plus receive our monthly report.
+                </p>
+                <p>
+                  <a href="#">Subscribe our newsletter</a>
+                </p>
+              </div>
             </div>
-          </div>
-          <div class="column">
-            <div class="ui basic segment">
-              <div><span class="ui label">Update</span></div>
-              <h4>You are all up to date</h4>
-              <p>
-                We post important announcements, news and updates in this area. You can also check out our <a href="https://blog.readthedocs.com/">blog</a> or subscribe the newsletter to receive future updates first hand, plus receive our monthly report.
-              </p>
-              <p>
-                <a href="#">Subscribe our newsletter</a>
-              </p>
-            </div>
-          </div>
+          {% endif %}
+        {% endfor %}
 
-        </div>
       </div>
-      
     </div>
-
-  </section>
+  </div>
+</section>

--- a/readthedocs-theme/templates/readthedocs/includes/announcements.html
+++ b/readthedocs-theme/templates/readthedocs/includes/announcements.html
@@ -17,7 +17,7 @@
                     {% endif %}
                   </span>
                 </div>
-                <h4>{{ article.title }}</h4>
+                <h4><a href="/{{ article.url }}">{{ article.title }}</a></h4>
                 <p>
                   {% if article.description %}
                     {{ article.description|striptags|escape }}


### PR DESCRIPTION
This automates the announcements section by grabbing the last 3 blog posts that have the `tag` `homepage`.

If there are less then 3 articles tagged `homepage`, then the default **"You are all up to date"** announcement, with links to the blog and newsletter subscription, is shown instead.

![Screenshot 2022-03-09 184735](https://user-images.githubusercontent.com/4049894/157510370-3d4183ca-d40b-45c3-a438-7c8418fc811d.png)

Closes: #62 and #88 