### PR TITLE
Removes footer column wrap on tablet

### DIFF
--- a/readthedocs-theme/templates/includes/footer.html
+++ b/readthedocs-theme/templates/includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="ui basic inverted segment very padded" id="footer">
   <div class="ui container">
 
-      <div class="ui three column stackable grid information very padded">
+      <div class="ui three column stackable grid information very padded text center mobile">
 
         <div class="column">
           <h4 class="ui sub header">Stay Updated</h4>

--- a/readthedocs-theme/templates/includes/footer.html
+++ b/readthedocs-theme/templates/includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="ui basic inverted segment very padded" id="footer">
   <div class="ui container">
 
-      <div class="ui three column stackable grid information very padded text center mobile">
+      <div class="ui three column stackable grid information very padded text align center mobile">
 
         <div class="column">
           <h4 class="ui sub header">Stay Updated</h4>

--- a/readthedocs-theme/templates/includes/footer.html
+++ b/readthedocs-theme/templates/includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="ui basic inverted segment very padded" id="footer">
   <div class="ui container">
 
-      <div class="ui three column stackable doubling grid information very padded">
+      <div class="ui three column stackable grid information very padded">
 
         <div class="column">
           <h4 class="ui sub header">Stay Updated</h4>


### PR DESCRIPTION
Prevents the 3 footer columns from wrapping on table breakpoints.

Fixes:  #104 
Requires: #106 