### PR TITLE
Improve home page callout responsive behaviour

### DIFF
--- a/readthedocs-theme/templates/readthedocs/homepage.html
+++ b/readthedocs-theme/templates/readthedocs/homepage.html
@@ -12,24 +12,24 @@
 
         <div class="row">
 
-          <div class="column seven wide computer nine wide tablet sixteen wide mobile">
-            <h1 class="ui header massive">
+          <div class="column seven wide computer twelve wide tablet sixteen wide mobile">
+            <h1 class="ui header massive center align text tablet mobile">
               <span class="ui header">Push your docs, <br>we'll do the rest</span>
             </h1>
-            <div class="ui basic vertical padded huge segment">
+            <div class="ui basic vertical padded huge segment center align text tablet mobile">
               <p>
                 Make documentation part of your project workflow with simplified processes that automate building, versioning and hosting of your docs.
               </p>
             </div>
             
-            <div>
+            <div class="center align text tablet mobile">
               <a href="https://docs.readthedocs.io/page/intro/getting-started-with-sphinx.html" class="ui button large secondary gradient fade">Get started!</a>
               <a href="./product.html" class="ui button large secondary basic">Learn more</a>
             </div>
           
           </div>
 
-          <div class="column seven wide computer nine wide tablet sixteen wide mobile">
+          <div class="seven wide computer only column">
             <img src="/theme/img/shutterstock-concept-of-user-manual-1315141181-2.jpg"/>
           </div>
 


### PR DESCRIPTION
Hides the callout image and centers the text for tablet and bellow viewports.

Closes: #103 
Requires: #106

Preview on mobile:
![Screenshot 2022-03-15 091249](https://user-images.githubusercontent.com/4049894/158346053-d1a2d3f7-d75a-409f-88d4-8d4693aa4dad.png)

