### PR TITLE
Improve home page how it works responsive behaviour

### DIFF
--- a/readthedocs-theme/templates/readthedocs/homepage.html
+++ b/readthedocs-theme/templates/readthedocs/homepage.html
@@ -50,9 +50,9 @@
 
       <div class="ui grid centered">
         <div class="row">
-          <div class="column fourteen wide computer sixteen wide tablet">
+          <div class="column fourteen wide computer sixteen twelve tablet ten wide mobile">
         
-            <h2 class="ui header">How it works</h2>
+            <h2 class="ui header text align center mobile">How it works</h2>
 
             <div class="ui grid stackable three column">
 


### PR DESCRIPTION
Improves the home page "How it works" section responsive behaviour by centering the header text and limiting the columns width on mobile viewport devices.

Preview on **648px**:
![Screenshot 2022-03-15 095039](https://user-images.githubusercontent.com/4049894/158351896-f278d725-0330-4f61-8709-478e812bf3f9.png)


* Closes: #105 
* Requires: #106

Note: The `mobile` viewport encompasses a large number of device widths, from the larger **768px** phones to the smallest under **320px**. The current proposed solution using SUI [device only](https://fomantic-ui.com/collections/grid.html#device-visibility) grid options cannot account for different displays for devices within this group. This means that the **10/16th** column that seems large on **768px** can become weirdly narrow on **320px** devices.