### PR TITLE
Try build jobs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,18 @@
+version: 2
+
+sphinx:
+  configuration: "./conf.py"
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+    nodejs: "14"
+  jobs:
+    pre_build:
+      - pip install -r requirements.txt
+      - npm ci
+      - npm run build-html
+    post_build:
+      - rm -rfv ../../artifacts/${READTHEDOCS_VERSION}/sphinx
+      - mv -v ./output/ ../../artifacts/${READTHEDOCS_VERSION}/sphinx

--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,13 @@
+# This is mostly a hack to bail out of Sphinx
+
+import sys
+
+project = 'site-communtiy'
+copyright = '2022, Test'
+author = 'Test'
+
+extensions = []
+
+
+def setup(app):
+    sys.exit(0)

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,8 +1,14 @@
 """Read the Docs website Pelican configuration."""
 
+import os
+
 AUTHOR = 'Read the Docs, Inc'
 SITENAME = 'Read the Docs'
 SITEURL = ''
+
+rtd_version = os.environ.get('READTHEDOCS_VERSION')
+if rtd_version:
+    SITEURL = f'/en/{rtd_version}/'
 
 TIMEZONE = 'US/Pacific'
 DEFAULT_LANG = 'en'


### PR DESCRIPTION
I was mostly curious about what this would look like, but it was rather easy to accomplish.

This enables building with Pelican and uses a dummy Sphinx configuration to mostly skip the Sphinx build step. The one hurdle was knowing you needed to put the files in a certain location to get them cloned to RTD storage.

For this use case, build.jobs + a generic builder that skipped Sphinx and collected my build files would be enough -- so probably no metadata.yaml or build.commands required