### PR TITLE
Add a `stretched row` for equal height columns in the signup modal

### DIFF
--- a/content/partials/homepage.html
+++ b/content/partials/homepage.html
@@ -13,82 +13,85 @@
       </div>
 
       <div class="ui stacking centered grid">
+        <div class="stretched row">
 
-        <div class="seven wide computer sixteen wide tablet column">
-          <div class="ui raised segment">
-            <div class="ui header">
-              Read the Docs Community
-              <div class="sub header">
-                For free and open-source projects
+          <div class="seven wide computer sixteen wide tablet column">
+            <div class="ui raised segment">
+              <div class="ui header">
+                Read the Docs Community
+                <div class="sub header">
+                  For free and open-source projects
+                </div>
               </div>
-            </div>
 
-            <div class="ui relaxed list">
-              <div class="item">
-                <i class="fad fa-lock-open primary icon"></i>
-                Clone public repositories
+              <div class="ui relaxed list">
+                <div class="item">
+                  <i class="fad fa-lock-open primary icon"></i>
+                  Clone public repositories
+                </div>
+                <div class="item">
+                  <i class="fad fa-eye primary icon"></i>
+                  Public documentation
+                </div>
+                <div class="item">
+                  <i class="fad fa-rectangle-ad primary icon"></i>
+                  Ads supported hosting
+                </div>
               </div>
-              <div class="item">
-                <i class="fad fa-eye primary icon"></i>
-                Public documentation
-              </div>
-              <div class="item">
-                <i class="fad fa-rectangle-ad primary icon"></i>
-                Ads supported hosting
-              </div>
-            </div>
 
-            <div class="ui center aligned basic fitted segment">
-              <p>
-                <b>Free</b> for open-source software.
-              </p>
+              <div class="ui center aligned basic fitted segment">
+                <p>
+                  <b>Free</b> for open-source software.
+                </p>
 
-              <a class="ui primary center aligned button"
-                 href="https://readthedocs.org/accounts/signup/">
-                Sign up
-              </a>
+                <a class="ui primary center aligned button"
+                   href="https://readthedocs.org/accounts/signup/">
+                  Sign up
+                </a>
+              </div>
             </div>
           </div>
-        </div>
 
-        <div class="seven wide computer sixteen wide tablet column">
-          <div class="ui raised segment">
-            <div class="ui header">
-              Read the Docs for Business
-              <div class="sub header">
-                For commercial and non-free projects
+          <div class="seven wide computer sixteen wide tablet column">
+            <div class="ui raised segment">
+              <div class="ui header">
+                Read the Docs for Business
+                <div class="sub header">
+                  For commercial and non-free projects
+                </div>
               </div>
-            </div>
 
-            <div class="ui relaxed list">
-              <div class="item">
-                <i class="fad fa-lock-keyhole primary icon"></i>
-                Clone private and public repositories
+              <div class="ui relaxed list">
+                <div class="item">
+                  <i class="fad fa-lock-keyhole primary icon"></i>
+                  Clone private and public repositories
+                </div>
+                <div class="item">
+                  <i class="fad fa-eye-slash primary icon"></i>
+                  Public and private documentation
+                </div>
+                <div class="item">
+                  <i class="fad fa-users primary icon"></i>
+                  Team management for your organization
+                </div>
               </div>
-              <div class="item">
-                <i class="fad fa-eye-slash primary icon"></i>
-                Public and private documentation
-              </div>
-              <div class="item">
-                <i class="fad fa-users primary icon"></i>
-                Team management for your organization
-              </div>
-            </div>
 
-            <div class="ui center aligned basic fitted segment">
-              <p>
-                Plans starting at <b>$50/month</b>.
-              </p>
+              <div class="ui center aligned basic fitted segment">
+                <p>
+                  Plans starting at <b>$50/month</b>.
+                </p>
 
-              <a class="ui primary center aligned button"
-                 href="https://readthedocs.com/accounts/signup">
-                Sign up
-              </a>
+                <a class="ui primary center aligned button"
+                   href="https://readthedocs.com/accounts/signup">
+                  Sign up
+                </a>
+              </div>
             </div>
           </div>
-        </div>
 
+        </div>
       </div>
+
     </div>
 
     <div class="actions">


### PR DESCRIPTION
Just noticed the columns weren't the same height, which wasn't intended.
Adding the stretched row is what makes the segments fill the full
row/table height.


<!-- readthedocs-preview read-the-docs-site-community start -->
----
:books: Documentation preview :books:: https://read-the-docs-site-community--150.com.readthedocs.build/en/150/

<!-- readthedocs-preview read-the-docs-site-community end -->