### PR TITLE
Fix top nav width at computer and tablet

### DIFF
--- a/readthedocs_theme/templates/includes/topnav.html
+++ b/readthedocs_theme/templates/includes/topnav.html
@@ -102,7 +102,7 @@
         The top menu shown on tablet/computer. Horizontal menu items instead of dropdown.
       #}
       {% block topnav_menu %}
-        <div class="eleven wide left aligned tablet only computer only column">
+        <div class="twelve wide computer eleven wide tablet left aligned tablet only computer only column">
           <div class="ui huge borderless secondary menu">
             {{ menu_main() }}
 


### PR DESCRIPTION
The topnav was tuned for tablet display, where the logo column is one
column wider. On desktop viewport sizes, the topnav showed one column
too narrow.

Tablet:
![image](https://user-images.githubusercontent.com/1140183/201817880-d5ee703e-6c3d-4411-9b43-2ad32ded4b39.png)

And desktop viewport is now full width.

Before:
![image](https://user-images.githubusercontent.com/1140183/201818109-174a21a6-5e51-45b4-bae7-0e6a21a1e9a7.png)

After:
![image](https://user-images.githubusercontent.com/1140183/201818083-b2eeec57-4948-47f3-a216-76322c29bdaa.png)



<!-- readthedocs-preview read-the-docs-site-community start -->
----
:books: Documentation preview :books:: https://read-the-docs-site-community--170.com.readthedocs.build/en/170/

<!-- readthedocs-preview read-the-docs-site-community end -->