### PR TITLE
Add Mastodon to Community website

### DIFF
--- a/readthedocs_theme/templates/includes/footer.html
+++ b/readthedocs_theme/templates/includes/footer.html
@@ -14,6 +14,7 @@
               <div class="item">
                 <a href="https://github.com/readthedocs/" aria-label="Read the Docs on GitHub" rel="noopener noreferrer"><i class="icon large fab fa-github"></i></a>
                 <a href="https://twitter.com/readthedocs" aria-label="Read the Docs on Twitter" rel="noopener noreferrer"><i class="icon large fab fa-twitter"></i></a>
+                <a href="https://fosstodon.org/@readthedocs" aria-label="Read the Docs on Mastodon / Fediverse" rel="me"><i class="icon large fab fa-mastodon"></i></a>
               </div>
             {% endblock menu_news %}
           </div>


### PR DESCRIPTION
Quick change proposal:

I'm not sure what version of Font Awesome we are running, and I didn't take time to setup a development environment yet.

This change will mark our website as "Verified" in our Mastodon profile because of the rel=me attribute. See: https://docs.joinmastodon.org/user/profile/#verification

<!-- readthedocs-preview read-the-docs-site-community start -->
----
:books: Documentation preview :books:: https://read-the-docs-site-community--175.com.readthedocs.build/en/175/

<!-- readthedocs-preview read-the-docs-site-community end -->