### PR TITLE
Make the GHA "preview" single version

### DIFF
--- a/.github/workflows/documentation-links.yaml
+++ b/.github/workflows/documentation-links.yaml
@@ -15,4 +15,4 @@ jobs:
         with:
           project-slug: "read-the-docs-site-community"
           platform: "business"
-          single-version: "true"
+          single-version: "true" # Has to be a string value. 

--- a/.github/workflows/documentation-links.yaml
+++ b/.github/workflows/documentation-links.yaml
@@ -15,4 +15,4 @@ jobs:
         with:
           project-slug: "read-the-docs-site-community"
           platform: "business"
-
+          single-version: "true"


### PR DESCRIPTION
Use the new feature of our own preview action.

See https://github.com/readthedocs/actions/pull/16

<!-- readthedocs-preview read-the-docs-site-community start -->
----
:books: Documentation preview :books:: https://read-the-docs-site-community--179.com.readthedocs.build/en/179/

<!-- readthedocs-preview read-the-docs-site-community end -->