### PR TITLE
content: fix typos and copy issues across marketing pages

### DIFF
--- a/content/pages/choosing-a-platform.rst
+++ b/content/pages/choosing-a-platform.rst
@@ -63,7 +63,7 @@ Important points:
 .. raw:: html
 
    <div class="ui basic center aligned padded segment">
-     <a class="ui violet button" href="https://readthedocs.com/accounts/signup/" data-analytics="commercial-signup">Start your 30-day free trial</a>
+     <a class="ui violet button" href="https://app.readthedocs.com/accounts/signup/" data-analytics="commercial-signup">Start your 30-day free trial</a>
    </div>
 
 Questions?

--- a/content/pages/company.html
+++ b/content/pages/company.html
@@ -181,7 +181,7 @@
           <div class="ui segment basic">
             <h3 class="ui header">Our blog</h3>
             <p>
-              This is where we post all the week to week progress updates and announcements.
+              This is where we post all our week-to-week progress updates and announcements.
             </p>
             <p>
               <a href="https://blog.readthedocs.com/">Check it out!</a>

--- a/content/pages/comparisons/cloudflare-pages.html
+++ b/content/pages/comparisons/cloudflare-pages.html
@@ -42,7 +42,7 @@
     {{ comparison.feature_row("Custom 404 pages", "Style 404 pages with context-related information", "fa-xmark", on_other=True) }}
     {{ comparison.feature_row("Documentation tool agnostic", "Use the documentation tool your team prefers (Sphinx, MkDocs, Docusaurus, etc)", "fa-book", on_other=True) }}
     {{ comparison.feature_row("Custom theme", "Style the documentation as you like", "fa-pen-swirl", on_other=True) }}
-    {{ comparison.feature_row("Private documention", "Give access only to trusted people", "fa-lock", on_other=True) }}
+    {{ comparison.feature_row("Private documentation", "Give access only to trusted people", "fa-lock", on_other=True) }}
     {{ comparison.feature_row("Advanced collaboration", "Unlimited users", "fa-people-group", on_other=True) }}
     {{ comparison.feature_row("Unlimited builds per month", "Trigger as many builds as you need", "fa-infinity") }}
     {{ comparison.feature_row("Multiple versions", "Publish multiple versions of your documentation", "fa-books") }}
@@ -72,7 +72,7 @@
               </h2>
 
               <p>
-                Cloudflare Pages is a great product, but it's more thought for deploying SPA (single-page applications) with fewer options for documentation sites.
+                Cloudflare Pages is a great product, but it's better suited for deploying SPAs (single-page applications) with fewer options for documentation sites.
                 For publishing great documentation <strong>without having to build the features yourself</strong>,
                 Read the Docs is the <em>all-in-one solution</em> that provides everything you need out of the box!
               </p>

--- a/content/pages/comparisons/gitbook.html
+++ b/content/pages/comparisons/gitbook.html
@@ -42,7 +42,7 @@
     {{ comparison.feature_row("Page analytics", "Understand how people browse your documentation", "fa-chart-mixed", on_other=True) }}
     {{ comparison.feature_row("Redirects", "Redirect users to the right page", "fa-arrows-turn-right", on_other=True) }}
     {{ comparison.feature_row("Translations", "Serve translated versions of your docs", "fa-language", on_other=True) }}
-    {{ comparison.feature_row("Private documention", "Give access only to trusted people", "fa-lock", on_other=True) }}
+    {{ comparison.feature_row("Private documentation", "Give access only to trusted people", "fa-lock", on_other=True) }}
     {{ comparison.feature_row("Preview changes from forked repositories", "Visualize edits from external collaborators", "fa-people-group") }}
     {{ comparison.feature_row("Static hosting", "Publish any static content", "fa-page") }}
     {{ comparison.feature_row("Visual diff on deploy previews", "Visualize differences directly on the rendered version", "fa-face-monocle") }}

--- a/content/pages/comparisons/github-pages.html
+++ b/content/pages/comparisons/github-pages.html
@@ -73,7 +73,7 @@
     {{ comparison.feature_row("Page analytics", "Understand how people browse your documentation", "fa-chart-mixed") }}
     {{ comparison.feature_row("Search analytics", "Explore what people search for in your docs", "fa-chart-simple") }}
     {{ comparison.feature_row("Translations", "Serve translated versions of your docs", "fa-language") }}
-    {{ comparison.feature_row("Private documention", "Give access only to trusted people", "fa-lock") }}
+    {{ comparison.feature_row("Private documentation", "Give access only to trusted people", "fa-lock") }}
     {{ comparison.feature_row("No usage limits", "Build and store as much as you need", "fa-hard-drive") }}
     {{ comparison.feature_row("Open Source", "Maintained by the community", "fa-brands fa-osi") }}
     {% endcall %}

--- a/content/pages/comparisons/netlify.html
+++ b/content/pages/comparisons/netlify.html
@@ -48,7 +48,7 @@
     {{ comparison.feature_row("Translations", "Serve translated versions of your docs", "fa-language") }}
     {{ comparison.feature_row("Visual diff on deploy previews", "Visualize differences directly on the rendered version", "fa-face-monocle") }}
     {{ comparison.feature_row("Search analytics", "Explore what people search for in your docs", "fa-chart-simple") }}
-    {{ comparison.feature_row("Private documention", "Give access only to trusted people", "fa-lock") }}
+    {{ comparison.feature_row("Private documentation", "Give access only to trusted people", "fa-lock") }}
     {{ comparison.feature_row("Unlimited builds per month", "Trigger as many builds as you need", "fa-infinity") }}
     {{ comparison.feature_row("Open Source", "No lock in and contribute back", "fa-brands fa-osi") }}
     {% endcall %}

--- a/content/pages/features.html
+++ b/content/pages/features.html
@@ -309,7 +309,7 @@
           icon=icon_3) %}
         {% markdown %}
         Rebuild your documentation and preview changes in every pull request.
-        Share changes easily and help catch errors before shipping documentaiton updates.
+        Share changes easily and help catch errors before shipping documentation updates.
 
         Supported on **GitHub** and **GitLab** repositories.
         {% endmarkdown %}

--- a/content/pages/features/reader.html
+++ b/content/pages/features/reader.html
@@ -41,7 +41,7 @@
             {# This should be a list of benefits, not features, since we have a feature listing in the side nav #}
             <div class="ui list">
               <div class="item"><i class="fad fa-check secondary icon"></i>Easily find content with great search</div>
-              <div class="item"><i class="fad fa-check secondary icon"></i>Allow users to browser docs for the exact version they're using</div>
+              <div class="item"><i class="fad fa-check secondary icon"></i>Allow users to browse docs for the exact version they're using</div>
               <div class="item"><i class="fad fa-check secondary icon"></i>Alert users who are using old versions</div>
               <div class="item"><i class="fad fa-check secondary icon"></i>Easily download docs before their flight</div>
             </div>
@@ -64,7 +64,7 @@
                 <i class="fad {{ icon_2 }} secondary big icon"></i>
                 <span class="content">
                   {{ header_2 }}
-                  <span class="sub header">Warn readers about reading and old version of the documentation.</span>
+                  <span class="sub header">Warn readers about reading an old version of the documentation.</span>
                 </span>
               </a>
 
@@ -155,7 +155,7 @@
           icon=icon_3) %}
         {% markdown %}
         Always find what you are looking for at the tip of your fingers with our powerful ElasticSearch engine.
-        Search on a **single or accross multiple projects** at once.
+        Search on a **single or across multiple projects** at once.
         {% endmarkdown %}
         <a class="ui basic primary button" href="https://docs.readthedocs.io/page/server-side-search/index.html">
           <i class="fad fa-book icon" aria-hidden="true"></i>

--- a/content/posts/enable-beta-addons.md
+++ b/content/posts/enable-beta-addons.md
@@ -70,7 +70,7 @@ comes from a pull request to clearly distinguish this version from the official 
 ![Flyout Addons](/images/addons-flyout.png)
 
 The _flyout_ is the small floating Read the Docs section where all the documentation versions and translations are listed.
-This allows readers to **find the exact version they are looking for** and also read the documention in their own language if it's available.
+This allows readers to **find the exact version they are looking for** and also read the documentation in their own language if it's available.
 Besides, it contains useful links to go to the project's home, builds page and offline formats such as PDFs and ebooks.
 
 ### Non-stable notification


### PR DESCRIPTION
## Summary

Review pass of the marketing pages for typos, grammar, and inconsistent copy.

- Fix "documention"/"documentaiton" misspellings on `features.html`, all four comparison pages (github-pages, cloudflare-pages, netlify, gitbook), and one blog post.
- Fix grammar in `features/reader.html`: `browser` → `browse`, `reading and old version` → `reading an old version`, `accross` → `across`.
- Fix awkward phrasing on `cloudflare-pages.html` (`more thought for deploying SPA` → `better suited for deploying SPAs`) and `company.html` (`week to week` → `week-to-week`).
- Correct the signup URL on `choosing-a-platform.rst` from `readthedocs.com/accounts/signup/` to `app.readthedocs.com/accounts/signup/` to match every other link on the site.

The `brand-guidelines.readthedocs.org` link on `company.html` was verified to still resolve and was left as-is.

## Test plan

- [ ] Build the site locally and spot-check the edited pages render correctly.
- [ ] Click through the signup button on `/choosing-a-platform/` to confirm it lands on the Business signup flow.

Generated by AI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ks6wn5Tw738gLcedMffLNH)_