### PR TITLE
content: expand doc tool to documentation tool

### DIFF
--- a/content/pages/comparisons/readme.html
+++ b/content/pages/comparisons/readme.html
@@ -37,7 +37,7 @@
     </p>
     <p>
       Read the Docs takes a different approach: <strong>docs as code</strong>.
-      Write in <strong>any doc tool</strong> your team already uses, versioned in the same Git repository as your code and reviewed in pull requests like any other change.
+      Write in <strong>any documentation tool</strong> your team already uses, versioned in the same Git repository as your code and reviewed in pull requests like any other change.
       Over 15 years of reliable documentation hosting, trusted by engineering teams at <strong>AMD</strong> and <strong>Canonical</strong>, and by open source projects like <strong>Jupyter</strong> and <strong>Flask</strong>.
     </p>
     <p>

--- a/content/pages/homepage.html
+++ b/content/pages/homepage.html
@@ -116,7 +116,7 @@
 
           <div class="ui centered vertically padded container stackable grid">
 
-            {% call homepage.feature_detail_item(header="Supports any doc tool", icon="fad fa-terminal") %}
+            {% call homepage.feature_detail_item(header="Supports any documentation tool", icon="fad fa-terminal") %}
               Integrated support for <strong><a href="/tools/sphinx/">Sphinx</a></strong>, <strong><a href="/tools/mkdocs/">MkDocs</a></strong>, <strong><a href="/tools/jupyter-book/">Jupyter Book</a></strong>, <strong>Docusaurus</strong>, and more.
               Flexible enough to work with any documentation tool.
             {% endcall %}


### PR DESCRIPTION
## Summary

"Doc tool" reads as jargon-y shorthand on a marketing page. Expanding to "documentation tool" in the two remaining user-facing instances: the homepage feature header and the ReadMe comparison lead paragraph.

Jinja/YAML comments left as-is since they're not reader-facing.

---

_Generated by [Claude Code](https://claude.ai/code). Session: https://claude.ai/code/session_01RauZs2WN5Gunnp3LQ5jhBD_

---
_Generated by [Claude Code](https://claude.ai/code/session_01RauZs2WN5Gunnp3LQ5jhBD)_