### PR TITLE
Add AI model flexibility feature to comparison pages

### DIFF
--- a/content/pages/comparisons/gitbook.html
+++ b/content/pages/comparisons/gitbook.html
@@ -68,7 +68,7 @@
     {{ comparison.feature_row("Custom \"robots.txt\"", "Improve your SEO by telling bots how to explore your site", "fa-robot") }}
     {{ comparison.feature_row("Open Source", "No lock in and contribute back", "fa-brands fa-osi") }}
     {{ comparison.feature_row("Documentation tool agnostic", "Use the documentation tool your team prefers (Sphinx, MkDocs, Docusaurus, etc)", "fa-book") }}
-    {{ comparison.feature_row("Use any AI model on your docs", "Sources stay in your Git repo, so you can run any AI tool over them &mdash; including local models &mdash; instead of a vendor-locked one", "fa-sparkles") }}
+    {{ comparison.feature_row("Use any AI model on your docs", "Run any AI tool over your sources, even local models", "fa-sparkles") }}
     {{ comparison.feature_row("Custom theme", "Style the documentation as you like", "fa-pen-swirl") }}
     {% endcall %}
 

--- a/content/pages/comparisons/gitbook.html
+++ b/content/pages/comparisons/gitbook.html
@@ -68,6 +68,7 @@
     {{ comparison.feature_row("Custom \"robots.txt\"", "Improve your SEO by telling bots how to explore your site", "fa-robot") }}
     {{ comparison.feature_row("Open Source", "No lock in and contribute back", "fa-brands fa-osi") }}
     {{ comparison.feature_row("Documentation tool agnostic", "Use the documentation tool your team prefers (Sphinx, MkDocs, Docusaurus, etc)", "fa-book") }}
+    {{ comparison.feature_row("Use any AI model on your docs", "Sources stay in your Git repo, so you can run any AI tool over them &mdash; including local models &mdash; instead of a vendor-locked one", "fa-sparkles") }}
     {{ comparison.feature_row("Custom theme", "Style the documentation as you like", "fa-pen-swirl") }}
     {% endcall %}
 

--- a/content/pages/comparisons/mintlify.html
+++ b/content/pages/comparisons/mintlify.html
@@ -58,6 +58,7 @@
     {{ comparison.feature_row("Search analytics", "Explore what people search for in your docs", "fa-chart-simple", on_other=True) }}
     {{ comparison.feature_row("Private documentation", "Give access only to trusted people", "fa-lock", on_other=True) }}
     {{ comparison.feature_row("Documentation tool agnostic", "Use the documentation tool your team prefers (Sphinx, MkDocs, Docusaurus, Jupyter Book, etc)", "fa-book") }}
+    {{ comparison.feature_row("Use any AI model on your docs", "Sources stay in your Git repo, so you can run any AI tool over them &mdash; including local models &mdash; instead of a vendor-locked one", "fa-sparkles") }}
     {{ comparison.feature_row("No per-seat pricing", "Unlimited users on every plan", "fa-people-group") }}
     {{ comparison.feature_row("Unlimited builds per month", "Trigger as many builds as you need", "fa-infinity") }}
     {{ comparison.feature_row("Open Source", "Own your content, self-host if you want, contribute back", "fa-brands fa-osi") }}

--- a/content/pages/comparisons/mintlify.html
+++ b/content/pages/comparisons/mintlify.html
@@ -58,7 +58,7 @@
     {{ comparison.feature_row("Search analytics", "Explore what people search for in your docs", "fa-chart-simple", on_other=True) }}
     {{ comparison.feature_row("Private documentation", "Give access only to trusted people", "fa-lock", on_other=True) }}
     {{ comparison.feature_row("Documentation tool agnostic", "Use the documentation tool your team prefers (Sphinx, MkDocs, Docusaurus, Jupyter Book, etc)", "fa-book") }}
-    {{ comparison.feature_row("Use any AI model on your docs", "Sources stay in your Git repo, so you can run any AI tool over them &mdash; including local models &mdash; instead of a vendor-locked one", "fa-sparkles") }}
+    {{ comparison.feature_row("Use any AI model on your docs", "Run any AI tool over your sources, even local models", "fa-sparkles") }}
     {{ comparison.feature_row("No per-seat pricing", "Unlimited users on every plan", "fa-people-group") }}
     {{ comparison.feature_row("Unlimited builds per month", "Trigger as many builds as you need", "fa-infinity") }}
     {{ comparison.feature_row("Open Source", "Own your content, self-host if you want, contribute back", "fa-brands fa-osi") }}

--- a/content/pages/comparisons/readme.html
+++ b/content/pages/comparisons/readme.html
@@ -59,6 +59,7 @@
     {{ comparison.feature_row("Translations", "Serve translated versions of your docs", "fa-language", on_other=True) }}
     {{ comparison.feature_row("Interactive API reference", "Render an API explorer from your OpenAPI spec", "fa-plug", on_other=True, on_readthedocs=False) }}
     {{ comparison.feature_row("Documentation tool agnostic", "Use the documentation tool your team prefers (Sphinx, MkDocs, Docusaurus, Jupyter Book, etc)", "fa-book") }}
+    {{ comparison.feature_row("Use any AI model on your docs", "Sources stay in your Git repo, so you can run any AI tool over them &mdash; including local models &mdash; instead of a vendor-locked one", "fa-sparkles") }}
     {{ comparison.feature_row("No per-seat pricing", "Unlimited users on every plan", "fa-people-group") }}
     {{ comparison.feature_row("Open Source", "Own your content, self-host if you want, contribute back", "fa-brands fa-osi") }}
     {% endcall %}

--- a/content/pages/comparisons/readme.html
+++ b/content/pages/comparisons/readme.html
@@ -59,7 +59,7 @@
     {{ comparison.feature_row("Translations", "Serve translated versions of your docs", "fa-language", on_other=True) }}
     {{ comparison.feature_row("Interactive API reference", "Render an API explorer from your OpenAPI spec", "fa-plug", on_other=True, on_readthedocs=False) }}
     {{ comparison.feature_row("Documentation tool agnostic", "Use the documentation tool your team prefers (Sphinx, MkDocs, Docusaurus, Jupyter Book, etc)", "fa-book") }}
-    {{ comparison.feature_row("Use any AI model on your docs", "Sources stay in your Git repo, so you can run any AI tool over them &mdash; including local models &mdash; instead of a vendor-locked one", "fa-sparkles") }}
+    {{ comparison.feature_row("Use any AI model on your docs", "Run any AI tool over your sources, even local models", "fa-sparkles") }}
     {{ comparison.feature_row("No per-seat pricing", "Unlimited users on every plan", "fa-people-group") }}
     {{ comparison.feature_row("Open Source", "Own your content, self-host if you want, contribute back", "fa-brands fa-osi") }}
     {% endcall %}


### PR DESCRIPTION
## Summary
Added a new feature highlight across multiple comparison pages emphasizing the ability to use any AI model on documentation sources, positioning this as an advantage over vendor-locked alternatives.

This change emphasizes Read the Docs' flexibility advantage in AI tooling compared to competitors.

https://claude.ai/code/session_01Y7Z5gF4Mx1deVHwJU9Nows