### PR TITLE
Remove all monospace headers

### DIFF
--- a/content/pages/homepage.html
+++ b/content/pages/homepage.html
@@ -71,7 +71,7 @@
     <div class="ui inverted black stacked very padded large segment">
       <i class="fad olive fa-code-pull-request big shadowed icon" aria-hidden="true"></i>
 
-      <h2 class="ui small left aligned monospace header">
+      <h2 class="ui small left aligned header">
         Catch doc regressions before you merge
       </h2>
 

--- a/content/pages/pricing.html
+++ b/content/pages/pricing.html
@@ -134,7 +134,7 @@
           {% block pricing_opensource %}
             <div class="column">
               <div class="ui raised teal segment">
-                <h2 class="ui small monospace center aligned header">
+                <h2 class="ui small center aligned header">
                   Community
                 </h2>
 

--- a/content/partials/marketing.html
+++ b/content/partials/marketing.html
@@ -85,7 +85,7 @@
       <i class="fad {{ icon }} big shadowed icon"
          {%- if icon_style %} style="{{ icon_style }}"{% endif %}></i>
 
-      <h2 class="ui small left aligned monospace header">
+      <h2 class="ui small left aligned header">
         {{ header }}
       </h2>
 

--- a/content/partials/pricing.html
+++ b/content/partials/pricing.html
@@ -13,7 +13,7 @@
   <div class="{% if not _has_price %} computer only {%- endif %} column">
     <div class="ui {%- if _has_price %} raised {{ color }} {%- else %} basic {%- endif %} segment">
 
-      <h2 class="ui small monospace center aligned header">
+      <h2 class="ui small center aligned header">
         {{ name }}
       </h2>
 

--- a/readthedocs_theme/templates/error.html
+++ b/readthedocs_theme/templates/error.html
@@ -17,7 +17,7 @@
             {{ page_icon(page.icon, page.icon_style) }}
           </div>
           <div class="ui ten wide computer eleven wide tablet sixteen wide mobile column">
-            <h1 class="ui small left aligned monospace header">
+            <h1 class="ui small left aligned header">
               {{ page.title }}
               {% if page.subtitle %}
               <span class="sub header">


### PR DESCRIPTION
Headers should just use the `header` class.

This is separate from the fact that there's a font issue with monospace (the font stack isn't quite right).