### PR TITLE
theme: Remove blog welcome message from homepage

### DIFF
--- a/readthedocs_theme/templates/index.html
+++ b/readthedocs_theme/templates/index.html
@@ -56,39 +56,6 @@
         <div class="ui header">
           Latest blog posts
         </div>
-
-        <div class="ui info message">
-          <div class="header">
-            Welcome to our new blog
-          </div>
-          <div>
-            <p>
-              We will be adding news and updates here in the future.
-              Make sure to subscribe if you would like to be notified of new posts.
-            </p>
-
-            <div class="ui list">
-              <div class="item">
-                <i class="fad fa-envelope icon"></i>
-                <div class="content">
-                  Subscribe to <a href="https://landing.mailerlite.com/webforms/landing/t0a9l4" target="_blank">our newsletter</a>.
-                </div>
-              </div>
-              <div class="item">
-                <i class="fad fa-feed icon"></i>
-                <div class="content">
-                  Subscribe to <a href="/feeds/atom.xml" target="_blank">our Atom feed</a> with your favorite reader.
-                </div>
-              </div>
-              <div class="item">
-                <i class="fad fa-clock-rotate-left icon"></i>
-                <div class="content">
-                  Find our past posts and updates on <a href="https://blog.readthedocs.com/archive/" target="_blank">our archived blog</a>.
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
       {% endblock content_title %}
     </div>
   </section>


### PR DESCRIPTION
HS: Kill "whats new" in the blog page -- it's been a few years :)

Remove the informational message box that was displayed on the homepage's "Latest blog posts" section. This message included subscription options for the newsletter, Atom feed, and archived blog links.

**Key changes:**
- Removed the info message box containing welcome text and subscription links from the homepage template
- Keeps the "Latest blog posts" section header intact

This simplifies the homepage layout and removes the promotional content from the blog section.

---
*Generated by AI*

https://claude.ai/code/session_01NDNZTwQn16UfXErnMxmVqL