### PR TITLE
theme: Add Docs link to top navigation

### DIFF
--- a/readthedocs_theme/templates/includes/topnav.html
+++ b/readthedocs_theme/templates/includes/topnav.html
@@ -161,6 +161,10 @@
               Blog
             </a>
 
+            <a class="item" href="https://docs.readthedocs.io" target="_blank">
+              Docs
+            </a>
+
             <div class="right menu">
 
               <div class="item">


### PR DESCRIPTION
Add a link to the Read the Docs documentation in the top navigation menu.

**Key changes:**
- Added a new "Docs" navigation item linking to https://docs.readthedocs.io in the topnav template
- Link opens in a new tab using `target="_blank"`
- Positioned after the "Blog" link in the navigation menu

---
*Generated by AI*

https://claude.ai/code/session_0172fZryFJtEdXRGdxH81WWn