### PR TITLE
docs: fix pricing page plan inconsistencies

### DIFF
--- a/content/pages/pricing.html
+++ b/content/pages/pricing.html
@@ -48,7 +48,7 @@
 
           {% call pricing.plan(
             name="Basic",
-            tagline="For small teams getting started with private docs.",
+            tagline="For small teams getting started.",
             price_details=[("$50", "per month")],
             color="",
           ) %}
@@ -63,10 +63,11 @@
 
           {% call pricing.plan(
             name="Advanced",
-            tagline="For hosting public docs at your own domain.",
+            tagline="For growing teams with custom domains.",
             price_details=[("$150", "per month")],
             color="violet",
             inverted=True,
+            highlight=True,
           ) %}
             <div class="ui inverted list relaxed divided">
               {{ pricing.plan_feature("4 concurrent builds", None, "fa-rectangle-vertical-history fa-swap-opacity") }}
@@ -79,14 +80,14 @@
 
           {% call pricing.plan(
             name="Pro",
-            tagline="For organizations with scale and security needs.",
+            tagline="For larger organizations operating at scale.",
             price_details=[("$250", "per month")],
             color="",
           ) %}
             <div class="ui list relaxed divided">
               {{ pricing.plan_feature("6 concurrent builds", None, "fa-rectangle-vertical-history fa-swap-opacity") }}
               {{ pricing.plan_feature("15 custom domains", None, "fa-at") }}
-              {{ pricing.plan_feature("SSO with Google", None, "fa-key-skeleton") }}
+              {{ pricing.plan_feature("SSO with GitHub, GitLab, and Google", None, "fa-key-skeleton") }}
               {{ pricing.plan_feature("500 redirects", None, "fa-diamond-turn-right") }}
               {{ pricing.plan_feature("1 business day support", None, "fa-message-question") }}
             </div>
@@ -188,12 +189,12 @@
 <section id="pricing-questions">
   <div class="ui padded container">
     <div class="ui secondary center aligned padded segment">
-      <h3 class="ui small center aligned header">
+      <h2 class="ui medium center aligned header">
         <span class="content">
           <i class="fad fa-question-circle icon"></i>
           Not sure which plan fits?
         </span>
-      </h3>
+      </h2>
       <p>
         Tell us about your team and we'll help you find the right plan.
       </p>


### PR DESCRIPTION
## Summary

A review of the pricing page flagged a few internal inconsistencies between the plan cards, the compare table, and the page structure. This addresses the structural/correctness issues:

- **Pro SSO** — the Pro card listed only "SSO with Google" while the compare table lists "GitHub, GitLab, and Google", reading as if Pro *loses* providers the cheaper tiers have. The card now matches the table.
- **"Most popular" label** — the `plan()` macro already supports a `highlight` flag that renders an "Our most popular plan" label, but no card used it. Enabled on the Advanced plan.
- **Plan taglines** — the three taglines compared tiers on three different axes (doc visibility / domain / org size), making self-selection harder. Realigned onto a single team-size axis.
- **Heading level** — the closing "Not sure which plan fits?" section used `<h3>` while sibling top-level sections use `<h2>`; corrected for a consistent document outline.

Pure copy edits and Enterprise-tier presentation changes were intentionally left out of scope.

---
🤖 Generated by AI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtS5HVxDAvoXSweYjCu24k)_