### PR TITLE
docs: use "Read the Docs Business" consistently

### DIFF
--- a/content/pages/choosing-a-platform.rst
+++ b/content/pages/choosing-a-platform.rst
@@ -1,11 +1,11 @@
 :title: Choosing a platform
-:description: Learn more about the differences between Read the Docs community and Read the Docs for Business and which one is right for you.
+:description: Learn more about the differences between Read the Docs community and Read the Docs Business and which one is right for you.
 :template: docutils_page
 
 .. TODO: Figure out how to reuse substitions
 
 .. |org_brand| replace:: Read the Docs Community
-.. |com_brand| replace:: Read the Docs for Business
+.. |com_brand| replace:: Read the Docs Business
 
 Choosing a platform
 ===================
@@ -41,8 +41,8 @@ Important points:
 
 .. _EthicalAds: https://www.ethicalads.io/
 
-Read the Docs for Business
---------------------------
+Read the Docs Business
+----------------------
 
 |com_brand| is meant for companies and users who have more complex requirements
 for their documentation project. This can include commercial projects with

--- a/content/pages/privacy-policy.rst
+++ b/content/pages/privacy-policy.rst
@@ -35,7 +35,7 @@ readthedocs.org ("Read the Docs Community")
     writing and distributing technical documentation.
     This Privacy Policy applies to this site in full without reservation.
 
-readthedocs.com ("Read the Docs for Business")
+readthedocs.com ("Read the Docs Business")
     This website is a commercial hosted offering for hosting private
     documentation for corporate clients.
     This Privacy Policy applies to this site in full without reservation.
@@ -118,7 +118,7 @@ anyone (including us) may view their contents.
 If you have included private or sensitive information in your Documentation Site,
 such as email addresses, that information may be indexed by search engines or used by third parties.
 
-Read the Docs for Business may host `private projects </terms-of-service/#private-projects>`_ which we treat as confidential
+Read the Docs Business may host `private projects </terms-of-service/#private-projects>`_ which we treat as confidential
 and we only access them for support reasons, with your consent, or if required to for security reasons
 
 If you're a **child under the age of 13**, you may not have an account on Read the Docs.
@@ -244,7 +244,7 @@ For Read the Docs, this means:
 * Our full DNT policy is `available here`_.
 
 Our DNT policy applies without reservation
-to Read the Docs Community and Read the Docs for Business.
+to Read the Docs Community and Read the Docs Business.
 A best effort is made to apply this to Documentation Sites,
 but we do not have complete control over the contents of these sites.
 
@@ -393,7 +393,7 @@ our legal obligations, resolve disputes, and enforce our agreements,
 but barring legal requirements, we will delete your full profile.
 
 Our web server logs for Read the Docs Community,
-Read the Docs for Business, and Documentation Sites
+Read the Docs Business, and Documentation Sites
 are deleted after 10 days barring legal obligations.
 
 

--- a/content/pages/terms-of-service.rst
+++ b/content/pages/terms-of-service.rst
@@ -70,7 +70,7 @@ readthedocs.org ("Read the Docs Community")
     This Website is used by documentation authors and project maintainers for
     writing and distributing technical documentation.
 
-readthedocs.com ("Read the Docs for Business")
+readthedocs.com ("Read the Docs Business")
     This Website is a commercial hosted offering for hosting private
     documentation for corporate clients.
 
@@ -250,7 +250,7 @@ as necessary to render our Websites and provide our Services.
 Private projects
 ----------------
 
-**Short version:** *You may connect Read the Docs for Business to your private repositories or host documentation privately.
+**Short version:** *You may connect Read the Docs Business to your private repositories or host documentation privately.
 We treat the content of these private projects as confidential,
 and we only access it for support reasons, with your consent, or if required to for security reasons.*
 
@@ -435,7 +435,7 @@ Upgrades, downgrades, and changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - We will immediately bill you when you upgrade from the free plan to any paying plan
-  (either Read the Docs for Business or a Gold membership).
+  (either Read the Docs Business or a Gold membership).
 - If you change from a monthly billing plan to a yearly billing plan,
   Read the Docs will bill you for a full year at the next monthly billing date.
 - If you upgrade to a higher level of service, we will bill you for the upgraded plan immediately.

--- a/content/posts/newsletter-march-2022.rst
+++ b/content/posts/newsletter-march-2022.rst
@@ -24,7 +24,7 @@ New features
 In February we continued to work on refactors and internal changes.
 Among the major user-facing changes:
 
-- **We now have the CDN on Read the Docs for Business in beta**, with a couple accounts testing it. If you're interested, please `contact us`_.
+- **We now have the CDN on Read the Docs Business in beta**, with a couple accounts testing it. If you're interested, please `contact us`_.
 - You can now `cancel builds <https://github.com/readthedocs/readthedocs.org/pull/8850>`_ via a button in the dashboard. This will save resources, and allow you to ensure that you don't hit concurrency limits if you trigger a few builds at once.
 - Projects that are imported via the API are now required to have a VCS repository linked to them, if your organization has `VCS SSO <https://docs.readthedocs.io/en/latest/commercial/single-sign-on.html#sso-with-vcs-provider-github-bitbucket-or-gitlab>`_ turned on, so that users will be able to access it.
 

--- a/content/posts/postgres-maint-feb-14.md
+++ b/content/posts/postgres-maint-feb-14.md
@@ -11,7 +11,7 @@ image_credit: Photo by <a href="https://unsplash.com/@scottrodgerson?utm_content
 **Note**: As of 3PM PST, this is now complete.
 
 We wanted to make you aware that on **Friday, February 14 at 2:00pm PST (5:00pm EST, 22:00 UTC)**, Read the Docs will be having a scheduled downtime of approximately 2 hours.
-This will impact both **Read the Docs Community** and **Read the Docs for Business**.
+This will impact both **Read the Docs Community** and **Read the Docs Business**.
 We expect the downtime to only last for 15-30 minutes, but we are scheduling a longer window to account for any unforeseen issues.
 
 During this maintenance window, public documentation will continue to be online but new documentation builds will not trigger and the Read the Docs dashboard will be unavailable.

--- a/content/posts/read-the-docs-2021-stats.rst
+++ b/content/posts/read-the-docs-2021-stats.rst
@@ -16,7 +16,7 @@ Read the Docs had a lot of good things happen this year.
 
 We did a majority of the work on our `CZI grant <https://blog.readthedocs.com/czi-grant-announcement/>`_,
 grew our team from 5 to 8,
-and continued to grow our `EthicalAds network`_ & `Read the Docs for Business`_.
+and continued to grow our `EthicalAds network`_ & `Read the Docs Business`_.
 It's been another year of steady growth,
 and we hope to continue that into 2022.
 
@@ -108,15 +108,15 @@ Funding
 * $380,000 advertising (from $234,000)
 * $35,000 Gold users and donations (from $30,000)
 * 8 paid staff (from 5)
-* We have additional revenue from our `Read the Docs for Business`_, but aren't including that in our community funding overview
+* We have additional revenue from our `Read the Docs Business`_, but aren't including that in our community funding overview
 
 We are excited to continue to grow our advertising business,
 and expand it to the larger community.
-We are also seeing continued growth of our paid product, `Read the Docs for Business`_,
+We are also seeing continued growth of our paid product, `Read the Docs Business`_,
 which is allowing us to fund further growth of the Read the Docs codebase for all our users.
 
 .. _EthicalAds: https://www.ethicalads.io/
-.. _Read the Docs for Business: https://readthedocs.com/
+.. _Read the Docs Business: https://readthedocs.com/
 
 
 Conclusion

--- a/content/posts/read-the-docs-2023-stats.rst
+++ b/content/posts/read-the-docs-2023-stats.rst
@@ -93,12 +93,12 @@ Funding
 Overall our community site continues to be sustainable,
 and we're excited to be able to work on open source with a small team everyday.
 
-We have additional revenue from our `Read the Docs for Business`_ & EthicalAds_.
+We have additional revenue from our `Read the Docs Business`_ & EthicalAds_.
 Both of these continue to be great sources of revenue for us,
 and we're excited to continue proving the concept of ethical advertising.
 
 .. _EthicalAds: https://www.ethicalads.io/
-.. _Read the Docs for Business: https://about.readthedocs.com/
+.. _Read the Docs Business: https://about.readthedocs.com/
 
 .. The advertising revenue is ad revenue for RTD itself. Gotten from the Read the Docs publisher on EthicalAds.
 

--- a/content/posts/two-factor-authentication.md
+++ b/content/posts/two-factor-authentication.md
@@ -14,7 +14,7 @@ Two-factor authentication adds an extra layer of security to your account by req
 This helps protect your account from unauthorized access, even if your password is compromised.
 You can use an authenticator app like Google Authenticator or Authy to generate the codes.
 
-You can enable two-factor authentication from our new dashboard at <https://app.readthedocs.org/accounts/2fa/> (or <https://app.readthedocs.com/accounts/2fa/> for Read the Docs for Business users),
+You can enable two-factor authentication from our new dashboard at <https://app.readthedocs.org/accounts/2fa/> (or <https://app.readthedocs.com/accounts/2fa/> for Read the Docs Business users),
 or by following the steps from [our documentation](https://docs.readthedocs.io/en/stable/guides/management/2fa.html).
 
 We'd like to give a special thanks to the [django-allauth](https://allauth.org/) project for providing the foundation for our authentication system,

--- a/content/posts/website-migration.rst
+++ b/content/posts/website-migration.rst
@@ -12,7 +12,7 @@ Read the Docs website migration
 
 Read the Docs is in the process of migrating our primary marketing website to a single site: https://about.readthedocs.com.
 The new site offers users more information about our products and their features,
-in a combined presentation of what was previously divided between two websites (Read the Docs Community and Read the Docs for Business).
+in a combined presentation of what was previously divided between two websites (Read the Docs Community and Read the Docs Business).
 At the same time, the new site will also serve as a single entrypoint for users that are logging in to Read the Docs accounts.
 There has been a good deal of confusion around our two sites,
 and this change makes it more clear which site you're going to.

--- a/examples/mockups/company.html
+++ b/examples/mockups/company.html
@@ -363,7 +363,7 @@
 
               <div class="ui list">
                 <a class="item" href="{{ advertising_url | default:'https://readthedocs.org/sustainability/advertising/' }}">Advertise with Us</a>
-                <a class="item" href="https://readthedocs.com">Read the Docs for Business</a>
+                <a class="item" href="https://readthedocs.com">Read the Docs Business</a>
                 <a class="item" href='{{ donate_url }}'>Supporters</a>
                 <a class="item" href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>
                 <a class="item" href="https://docs.readthedocs.io/page/terms-of-service.html">Terms of Service</a>

--- a/examples/mockups/index.html
+++ b/examples/mockups/index.html
@@ -261,7 +261,7 @@
 
               <div class="ui list">
                 <a class="item" href="{{ advertising_url | default:'https://app.readthedocs.org/sustainability/advertising/' }}">Advertise with Us</a>
-                <a class="item" href="https://readthedocs.com">Read the Docs for Business</a>
+                <a class="item" href="https://readthedocs.com">Read the Docs Business</a>
                 <a class="item" href='{{ donate_url }}'>Supporters</a>
                 <a class="item" href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>
                 <a class="item" href="https://docs.readthedocs.io/page/terms-of-service.html">Terms of Service</a>

--- a/examples/mockups/pricing.html
+++ b/examples/mockups/pricing.html
@@ -42,11 +42,8 @@
 
         <div class="ui segment basic vertical padded">
           <div class="ui horizontal divider header">
-            <i class="icon building"></i> Read the Docs
+            <i class="icon building"></i> Read the Docs Business
           </div>
-          <h2 class="ui header centered">
-            <span class="ui header large">for Business</span>
-          </h2>
         </div>
 
         <div class="ui three stackable cards">
@@ -590,7 +587,7 @@
 
               <div class="ui list">
                 <a class="item" href="{{ advertising_url | default:'https://app.readthedocs.org/sustainability/advertising/' }}">Advertise with Us</a>
-                <a class="item" href="https://readthedocs.com">Read the Docs for Business</a>
+                <a class="item" href="https://readthedocs.com">Read the Docs Business</a>
                 <a class="item" href='{{ donate_url }}'>Supporters</a>
                 <a class="item" href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>
                 <a class="item" href="https://docs.readthedocs.io/page/terms-of-service.html">Terms of Service</a>

--- a/examples/mockups/product.html
+++ b/examples/mockups/product.html
@@ -334,7 +334,7 @@
 
               <div class="ui list">
                 <a class="item" href="{{ advertising_url | default:'https://app.readthedocs.org/sustainability/advertising/' }}">Advertise with Us</a>
-                <a class="item" href="https://readthedocs.com">Read the Docs for Business</a>
+                <a class="item" href="https://readthedocs.com">Read the Docs Business</a>
                 <a class="item" href='{{ donate_url }}'>Supporters</a>
                 <a class="item" href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>
                 <a class="item" href="https://docs.readthedocs.io/page/terms-of-service.html">Terms of Service</a>


### PR DESCRIPTION
Replace "Read the Docs for Business" with "Read the Docs Business"
across blog posts, terms/privacy pages, and example mockups.

https://claude.ai/code/session_01D7oPvaVTsDXGdLaRmHvJAt