### PR TITLE
Using NPM minimum age for dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
     description: "Run basic checks"
     steps:
       - checkout
-      - run: npm install -g "npm@11.10"
+      - run: npm install --prefix=$HOME/.local -g "npm@11.10"
       - run: npm ci
       - run: npm run lint
       - run: npm run test
@@ -18,7 +18,7 @@ commands:
       - checkout
       - node/install:
           node-version: "22.11"
-      - run: npm install -g "npm@11.10"
+      - run: npm install --prefix=$HOME/.local -g "npm@11.10"
       - run: npm ci
       - run: npm run build-assets
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ commands:
       - checkout
       - node/install:
           node-version: "22.11"
+      - run: npm install -g "npm@11.10"
       - run: npm ci
       - run: npm run build-assets
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ commands:
     description: "Run basic checks"
     steps:
       - checkout
-      - run: sudo npm install -g "npm@11.10"
       - run: npm ci
       - run: npm run lint
       - run: npm run test
@@ -17,8 +16,7 @@ commands:
     steps:
       - checkout
       - node/install:
-          node-version: "22.11"
-      - run: npm install -g "npm@11.10"
+          node-version: "24.16"
       - run: npm ci
       - run: npm run build-assets
       - run:
@@ -38,7 +36,7 @@ commands:
 jobs:
   lint:
     docker:
-      - image: "cimg/node:22.11"
+      - image: "cimg/node:24.16"
     steps:
       - run-lint: {}
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
       - checkout
       - node/install:
           node-version: "22.11"
-      - run: sudo npm install -g "npm@11.10"
+      - run: npm install -g "npm@11.10"
       - run: npm ci
       - run: npm run build-assets
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
     description: "Run basic checks"
     steps:
       - checkout
-      - run: npm install --prefix=$HOME/.local -g "npm@11.10"
+      - run: sudo npm install -g "npm@11.10"
       - run: npm ci
       - run: npm run lint
       - run: npm run test
@@ -18,7 +18,7 @@ commands:
       - checkout
       - node/install:
           node-version: "22.11"
-      - run: npm install --prefix=$HOME/.local -g "npm@11.10"
+      - run: sudo npm install -g "npm@11.10"
       - run: npm ci
       - run: npm run build-assets
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ commands:
     description: "Run basic checks"
     steps:
       - checkout
+      - run: npm install -g "npm@11.10"
       - run: npm ci
       - run: npm run lint
       - run: npm run test

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+min-release-age=14400

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 engine-strict=true
-min-release-age=14400
+min-release-age=14

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 engine-strict=true
-# Don't install packages younger than 14d, also set in .ncurc.mjs
+# Don't install packages younger than 14d
 min-release-age=14

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
+# Don't install packages younger than 14d, also set in .ncurc.mjs
 min-release-age=14

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,7 @@ build:
   commands:
     - pip install uv
     - uv sync
+    - npm install -g "npm@11.10"
     - npm ci
     - uv run npm run build-html
     - mkdir -p _readthedocs/html/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,8 +4,11 @@ build:
   os: ubuntu-26.04
   tools:
     python: "3.10"
-    nodejs: "24.16.0"
+    # TODO just install 24.16 when we finally support it
+    nodejs: "24"
   commands:
+    - asdf install nodejs 24.16.0
+    - asdf global nodejs 24.16.0
     - pip install uv
     - uv sync
     - npm ci

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,14 +1,13 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-26.04
   tools:
     python: "3.10"
-    nodejs: "22"
+    nodejs: "24"
   commands:
     - pip install uv
     - uv sync
-    - npm install -g "npm@11.10"
     - npm ci
     - uv run npm run build-html
     - mkdir -p _readthedocs/html/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   os: ubuntu-26.04
   tools:
     python: "3.10"
-    nodejs: "24"
+    nodejs: "24.16.0"
   commands:
     - pip install uv
     - uv sync

--- a/.tool-versions-example
+++ b/.tool-versions-example
@@ -1,3 +1,3 @@
-nodejs 22.11.0
+nodejs 24.16.0
 python 3.10.8
 uv 0.7.8

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ built using a number of Node dependencies.
 
 You will need the following requirements:
 
-* Node.js version ``22``
+* Node.js version ``24``
 * NPM version ``11.10``
 * Python version ``3.10`` (any release ``>=3.6`` works)
 * uv (Use ``asdf`` or see https://github.com/astral-sh/uv for installation instructions)
@@ -42,7 +42,6 @@ install all system level dependencies for you.
     $ cp .tool-versions-example .tool-versions
     $ asdf install
     $ asdf reshim
-    $ npm install -g 'npm@11.10'
 
 With the correct system dependencies configured, either with ``asdf`` or
 manually, you can install all package level dependencies with:

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ built using a number of Node dependencies.
 You will need the following requirements:
 
 * Node.js version ``22``
+* NPM version ``11.10``
 * Python version ``3.10`` (any release ``>=3.6`` works)
 * uv (Use ``asdf`` or see https://github.com/astral-sh/uv for installation instructions)
 
@@ -41,6 +42,7 @@ install all system level dependencies for you.
     $ cp .tool-versions-example .tool-versions
     $ asdf install
     $ asdf reshim
+    $ npm install -g 'npm@11.10'
 
 With the correct system dependencies configured, either with ``asdf`` or
 manually, you can install all package level dependencies with:
@@ -115,17 +117,11 @@ Linting is required for every pull request, skipping this step can cause the
 build to fail if your formatting doesn't match the intended output from
 ``prettier``.
 
-To run linting checks, which will only report errors:
+All linting is set up to run via ``pre-commit``:
 
 .. code:: console
 
-    $ npm run lint
-
-To automatically format code:
-
-.. code:: console
-
-    $ npm run format
+    $ pre-commit
 
 Authoring content
 -----------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,8 @@
         "webpack-watch-files-plugin": "^1.2.1"
       },
       "engines": {
-        "node": ">22.0.0"
+        "node": ">22.0.0",
+        "npm": ">11.10.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,8 +42,8 @@
         "webpack-watch-files-plugin": "^1.2.1"
       },
       "engines": {
-        "node": ">24.0.0",
-        "npm": ">11.10.0"
+        "node": ">=24.16.0",
+        "npm": ">=11.10.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "webpack-watch-files-plugin": "^1.2.1"
       },
       "engines": {
-        "node": ">22.0.0",
+        "node": ">24.0.0",
         "npm": ">11.10.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/readthedocs/website#readme",
   "engines": {
-    "node": ">24.0.0",
-    "npm": ">11.10.0"
+    "node": ">=24.16.0",
+    "npm": ">=11.10.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "homepage": "https://github.com/readthedocs/website#readme",
   "engines": {
-    "node": ">22.0.0"
+    "node": ">22.0.0",
+    "npm": ">11.10.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/readthedocs/website#readme",
   "engines": {
-    "node": ">22.0.0",
+    "node": ">24.0.0",
     "npm": ">11.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This enforces package age before installation for local package
installation. It does not address dependabot yet though, there is a
separate fix needed for this.