### PR TITLE
Add notice about june maintenance window for database upgrade

### DIFF
--- a/content/posts/scheduled-maintenance-june-2026.md
+++ b/content/posts/scheduled-maintenance-june-2026.md
@@ -1,0 +1,21 @@
+title: Scheduled database maintenance on June 19th
+date: 2026-06-01
+description: On Friday 19th, 2026 we will initiate a maintenance window for a routine database upgrade.
+category: Engineering
+tags: maintenance
+authors: Anthony Johnson
+status: published
+image: /images/aws-rds-upgrade.png
+image_credit: Photo by <a href="https://unsplash.com/@scottrodgerson?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Scott Rodgerson</a> on <a href="https://unsplash.com/photos/black-and-yellow-striped-line-BwMcYuHI9OI?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Unsplash</a>
+
+On **Friday, June 19th, 2026 at 3:00pm PST (6:00pm EST, 22:00 UTC)**,
+we are scheduling a maintenance window for a routine database upgrade.
+
+This will impact both **Read the Docs Community** and **Read the Docs Business**.
+We don't expect any downtime during the upgrade,
+but we are scheduling a maintenance window to account for any unforeseen issues.
+During this maintenance window,
+hosted documentation and the Read the Docs dashboard should both stay available.
+
+Feel free to [contact us](https://app.readthedocs.org/support/)
+if you have any further questions about this maintenance window.


### PR DESCRIPTION
Not sure if this is even needed, it looked like downtime was just going
to be a blip if anything. If we want to go for the major version upgrade
we should go ahead with this and maybe reframe the potential for
downtime.