### PR TITLE
Fix dev server public path to fix issues with JS dev bundle

### DIFF
--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -18,7 +18,9 @@ export default (env, argv) => {
     },
     output: {
       filename: is_production ? "js/[name].js?[contenthash]" : "js/[name].js",
-      chunkFilename: is_production ? "js/[name].js?[contenthash]" : "js/[name].js",
+      chunkFilename: is_production
+        ? "js/[name].js?[contenthash]"
+        : "js/[name].js",
       publicPath: "./",
       path: path.resolve(path.join("readthedocs_theme", "static")),
     },

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -17,8 +17,8 @@ export default (env, argv) => {
       moment: "moment",
     },
     output: {
-      filename: "js/[name].js?[contenthash]",
-      chunkFilename: "js/[name].js?[contenthash]",
+      filename: is_production ? "js/[name].js?[contenthash]" : "js/[name].js",
+      chunkFilename: is_production ? "js/[name].js?[contenthash]" : "js/[name].js",
       publicPath: "./",
       path: path.resolve(path.join("readthedocs_theme", "static")),
     },
@@ -160,7 +160,7 @@ export default (env, argv) => {
         "Access-Control-Allow-Origin": "*",
       },
       devMiddleware: {
-        publicPath: path.resolve("output"),
+        publicPath: "/theme/",
         index: true,
       },
       static: {


### PR DESCRIPTION
The production bundles were being served instead of the development
bundle when using the dev server. This enables debug mode and live
reloading of JS/CSS files on source file changes.

- Fixes #423